### PR TITLE
Update packages on ubuntu and freebsd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vagrant
+vagrant-ssh-config
+package_updates/roles/debian-update

--- a/package_updates/README.md
+++ b/package_updates/README.md
@@ -1,0 +1,39 @@
+# Update packages on ubuntu and freebsd
+:microscope: #1
+
+The Vagrant file being used is a copy from
+`https://github.com/stationgroup/vagrant-labs/tree/master/imperialspeculate`.
+
+Two roles are being used: debian-upgrade (an upstream Galaxy role) and
+freebsd-upgrade (a small role based on what was proposed in the comments of #1
+and extended with proper support for check mode.)
+
+The upgrade process is contained in the playbook os_upgrade.yml, which will
+automatically create proper groups for Ubuntu and FreeBSD hosts. If unneeded,
+this first play can be left out, and the target hosts: in the second play can be
+replaced by the relevant groups you have in the inventory (e.g. ec2 tags.)
+
+A local ansible.cfg is defined, and needed for these scripts to run out of the
+box. This implies that all ansible commands must be run from the
+`ansible-experiments/package_updates` folder.
+
+A small script `setup-requirements` is provided, that initializes everything,
+to be executed after the vagrant boxes came online. It will generate an
+ssh-config for said vagrant boxes, download roles from galaxy, and make a
+base-install for the hosts (installing python dependencies, ansible itself
+on ubuntu1, a deploying an ssh key to all nodes to be used from the vagrant box
+`ubuntu1`, as ansible controller machine.)
+
+When deploying and setting up from the machine where vagrant runs, you need to
+add some extra arguments:
+`--ssh-extra-args "-F ./vagrant-ssh-config" --inventory hosts-vagrant`
+to ansible execution. These are not necessary once running ansible from
+`ubuntu1`.
+
+## BUGS
+
+The vagrant setup seems to have a provisioning bug, that kicks in with the
+latest 18.04 Ubuntu. The FreeBSD boxes also experience a provisioning problem,
+with the same result: the second, private network interface does not get
+configured. As these interfaces are used to run ansible from `ubuntu1`, I could
+not fully test the scripts from there.

--- a/package_updates/Vagrantfile
+++ b/package_updates/Vagrantfile
@@ -1,0 +1,56 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# https://github.com/hashicorp/vagrant/issues/9442#issuecomment-363080565
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+
+  config.vm.define "ubuntu1" do |ubuntu1|
+    ubuntu1.vm.box = "ubuntu/xenial64"
+    ubuntu1.vm.hostname = "ubuntu1"
+    ubuntu1.vm.network "private_network", ip: "192.168.33.110"
+  end
+
+  config.vm.define "ubuntu2" do |ubuntu2|
+    ubuntu2.vm.box = "ubuntu/xenial64"
+    ubuntu2.vm.hostname = "ubuntu2"
+    ubuntu2.vm.network "private_network", ip: "192.168.33.120"
+  end
+
+  config.vm.define "ubuntu3" do |ubuntu3|
+    ubuntu3.vm.box = "ubuntu/bionic64"
+    ubuntu3.vm.hostname = "ubuntu3"
+    ubuntu3.vm.network "private_network", ip: "192.168.33.130"
+  end
+
+  config.vm.define "ubuntu4" do |ubuntu4|
+    ubuntu4.vm.box = "ubuntu/bionic64"
+    ubuntu4.vm.hostname = "ubuntu4"
+    ubuntu4.vm.network "private_network", ip: "192.168.33.140"
+  end
+
+  config.vm.define "freebsd5" do |freebsd5|
+    freebsd5.vm.box = "freebsd/FreeBSD-11.1-RELEASE"
+    freebsd5.vm.box_version = "2017.07.21"
+    freebsd5.vm.hostname = "freebsd5"
+    freebsd5.vm.network "private_network", ip: "192.168.33.150"
+    freebsd5.ssh.shell = "sh"
+    freebsd5.vm.base_mac = "080027D14C55"
+    freebsd5.vm.synced_folder ".", "/vagrant", type: "rsync"
+  end
+
+  config.vm.define "freebsd6" do |freebsd6|
+    freebsd6.vm.box = "freebsd/FreeBSD-11.1-RELEASE"
+    freebsd6.vm.box_version = "2017.07.21"
+    freebsd6.vm.hostname = "freebsd6"
+    freebsd6.vm.network "private_network", ip: "192.168.33.160"
+    freebsd6.ssh.shell = "sh"
+    freebsd6.vm.base_mac = "080027D14C66"
+    freebsd6.vm.synced_folder ".", "/vagrant", type: "rsync"
+  end
+end

--- a/package_updates/ansible.cfg
+++ b/package_updates/ansible.cfg
@@ -1,0 +1,9 @@
+[defaults]
+inventory = ./hosts
+roles_path = ./roles/
+host_key_checking = False
+retry_files_enabled = False
+#stdout_callback = json
+
+[privilege_escalation]
+become=True

--- a/package_updates/base-setup.yml
+++ b/package_updates/base-setup.yml
@@ -1,0 +1,56 @@
+---
+- name: install ansible requirements - ubuntu xenial
+  hosts: ubuntu[1..2]
+  gather_facts: false
+  tasks:
+    - name: install python2 (vagrant images seem to come with python3 only)
+      raw: apt install -y python python-apt
+
+- name: install ansible requirements - ubuntu bionic
+  hosts: ubuntu[3..4]
+  gather_facts: false
+  tasks:
+    - name: install python3-apt
+      raw: apt install -y python3-apt
+
+- name: install ansible requirements - freebsd
+  hosts: freebsd*
+  gather_facts: false
+  tasks:
+    - raw: pkg install --yes python
+
+- name: install ubuntu1 node as ansible control machine
+  hosts: ubuntu1
+  tasks:
+    - apt:
+        name:
+        - python3-pip
+    - pip:
+        name:
+          - pip
+          - setuptools
+          - cryptography
+          - paramiko
+        extra_args: --upgrade
+    - pip:
+        name: ansible
+        version: 2.5.2
+    - become_user: vagrant
+      git:
+        dest: ./ansible-experiments
+        repo: https://github.com/stationgroup/ansible-experiments
+    - become_user: vagrant
+      user:
+        name: vagrant
+        generate_ssh_key: true
+        ssh_key_bits: 2048
+        ssh_key_file: .ssh/id_rsa
+      register: vagrant_control_user
+
+- name: distribute vagrant@ubuntu1 ssh key
+  hosts: all
+  tasks:
+  - authorized_key:
+      key: '{{ hostvars.ubuntu1.vagrant_control_user.ssh_public_key }}'
+      user: vagrant
+

--- a/package_updates/hosts
+++ b/package_updates/hosts
@@ -1,0 +1,7 @@
+[imperialspeculate]
+ubuntu1 ansible_host=192.168.33.110 ansible_user=vagrant ansible_python_interpreter=/usr/bin/python3
+ubuntu2 ansible_host=192.168.33.120 ansible_user=vagrant ansible_python_interpreter=/usr/bin/python3
+ubuntu3 ansible_host=192.168.33.130 ansible_user=vagrant ansible_python_interpreter=/usr/bin/python3
+ubuntu4 ansible_host=192.168.33.140 ansible_user=vagrant ansible_python_interpreter=/usr/bin/python3
+freebsd5 ansible_host=192.168.33.150 ansible_user=vagrant ansible_python_interpreter=/usr/local/bin/python
+freebsd6 ansible_host=192.168.33.150 ansible_user=vagrant ansible_python_interpreter=/usr/local/bin/python

--- a/package_updates/hosts-vagrant
+++ b/package_updates/hosts-vagrant
@@ -1,0 +1,7 @@
+[imperialspeculate]
+ubuntu1 ansible_python_interpreter=/usr/bin/python3
+ubuntu2 ansible_python_interpreter=/usr/bin/python3
+ubuntu3 ansible_python_interpreter=/usr/bin/python3
+ubuntu4 ansible_python_interpreter=/usr/bin/python3
+freebsd5 ansible_python_interpreter=/usr/local/bin/python
+freebsd6 ansible_python_interpreter=/usr/local/bin/python

--- a/package_updates/os_upgrade.yml
+++ b/package_updates/os_upgrade.yml
@@ -1,0 +1,20 @@
+---
+- name: get facts and create os_type groups
+  hosts: all
+  gather_facts: True
+  tasks:
+  - group_by:
+      key: '{{ ansible_distribution }}'
+
+- name: upgrade debian based machines
+  hosts: mbuntu:FreeBSD
+  gather_facts: false
+  tasks:
+    - include_role:
+        name: debian-update
+      vars:
+        apt_update_cache_valid_time: 0
+      when: ansible_distribution in ['Debian', 'Ubuntu']
+    - include_role:
+        name: freebsd-update
+      when: ansible_distribution == 'FreeBSD'

--- a/package_updates/os_upgrade.yml
+++ b/package_updates/os_upgrade.yml
@@ -7,7 +7,7 @@
       key: '{{ ansible_distribution }}'
 
 - name: upgrade debian based machines
-  hosts: mbuntu:FreeBSD
+  hosts: ubuntu:FreeBSD
   gather_facts: false
   tasks:
     - include_role:

--- a/package_updates/roles/freebsd-update/tasks/main.yml
+++ b/package_updates/roles/freebsd-update/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Fetch any new FreeBSD updates
+  command: freebsd-update fetch --not-running-from-cron
+  check_mode: no
+  when: ansible_distribution == 'FreeBSD'
+  register: result_update
+  changed_when: "'No updates needed' not in result_update.stdout"
+
+- debug: var=result_update
+  when: result_update.changed
+
+- name: Install FreeBSD updates
+  command: freebsd-update install --not-running-from-cron
+  when: ansible_distribution == 'FreeBSD' and result_update.changed and not ansible_check_mode
+  register: result_update_install
+
+- debug: var=result_update_install
+  when: result_update_install.changed
+
+
+- name: Upgrade FreeBSD packages - dry-run
+  command: pkg upgrade --dry-run
+  check_mode: no
+  when: ansible_distribution == 'FreeBSD' and ansible_check_mode
+  register: result_pkg
+  changed_when: "'Your packages are up to date' not in result_pkg.stdout"
+
+- name: Upgrade FreeBSD packages
+  command: pkg upgrade --yes
+  when: ansible_distribution == 'FreeBSD' and not ansible_check_mode
+  register: result_pkg
+  changed_when: "'Your packages are up to date' not in result_pkg.stdout"
+
+- debug: var=result_pkg
+  when: result_pkg.changed

--- a/package_updates/roles/requirements.yml
+++ b/package_updates/roles/requirements.yml
@@ -1,0 +1,4 @@
+---
+- src: tersmitten.apt
+  version: v1.4.15
+  name: debian-update

--- a/package_updates/setup-requirements
+++ b/package_updates/setup-requirements
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -x
+set -e
+vagrant ssh-config > vagrant-ssh-config
+ansible-galaxy install -r roles/requirements.yml
+ansible-playbook --ssh-extra-args "-F ./vagrant-ssh-config" --inventory hosts-vagrant base-setup.yml
+ansible-playbook --ssh-extra-args "-F ./vagrant-ssh-config" --inventory hosts-vagrant os_upgrade.yml --check


### PR DESCRIPTION
Fixes #1

The Vagrant file being used is a copy from
`https://github.com/stationgroup/vagrant-labs/tree/master/imperialspeculate`.

Two roles are being used: debian-upgrade (an upstream Galaxy role) and
freebsd-upgrade (a small role based on what was proposed in the comments of #1
and extended with proper support for check mode.)

The upgrade process is contained in the playbook os_upgrade.yml, which will
automatically create proper groups for Ubuntu and FreeBSD hosts. If unneeded,
this first play can be left out, and the target hosts: in the second play can be
replaced by the relevant groups you have in the inventory (e.g. ec2 tags.)

A local ansible.cfg is defined, and needed for these scripts to run out of the
box. This implies that all ansible commands must be run from the
`ansible-experiments/package_updates` folder.

A small script `setup-requirements` is provided, that initializes everything,
to be executed after the vagrant boxes came online. It will generate an
ssh-config for said vagrant boxes, download roles from galaxy, and make a
base-install for the hosts (installing python dependencies, ansible itself
on ubuntu1, a deploying an ssh key to all nodes to be used from the vagrant box
`ubuntu1`, as ansible controller machine.)

When deploying and setting up from the machine where vagrant runs, you need to
add some extra arguments:
`--ssh-extra-args "-F ./vagrant-ssh-config" --inventory hosts-vagrant`
to ansible execution. These are not necessary once running ansible from
`ubuntu1`.

The vagrant setup seems to have a provisioning bug, that kicks in with the
latest 18.04 Ubuntu. The FreeBSD boxes also experience a provisioning problem,
with the same result: the second, private network interface does not get
configured. As these interfaces are used to run ansible from `ubuntu1`, I could
not fully test the scripts from there.