### PR TITLE
Feature package updates #4

### DIFF
--- a/package_updates/README.md
+++ b/package_updates/README.md
@@ -18,22 +18,14 @@ box. This implies that all ansible commands must be run from the
 `ansible-experiments/package_updates` folder.
 
 A small script `setup-requirements` is provided, that initializes everything,
-to be executed after the vagrant boxes came online. It will generate an
-ssh-config for said vagrant boxes, download roles from galaxy, and make a
-base-install for the hosts (installing python dependencies, ansible itself
-on ubuntu1, a deploying an ssh key to all nodes to be used from the vagrant box
-`ubuntu1`, as ansible controller machine.)
+including doing a vagrant up. It will generate an ssh-config for said vagrant
+boxes, download roles from galaxy, and make a base-install for the hosts
+(installing python dependencies, ansible itself on ubuntu1, a deploying an ssh
+key to all nodes to be used from the vagrant box `ubuntu1`, as
+ansible controller machine.)
 
 When deploying and setting up from the machine where vagrant runs, you need to
 add some extra arguments:
 `--ssh-extra-args "-F ./vagrant-ssh-config" --inventory hosts-vagrant`
 to ansible execution. These are not necessary once running ansible from
 `ubuntu1`.
-
-## BUGS
-
-The vagrant setup seems to have a provisioning bug, that kicks in with the
-latest 18.04 Ubuntu. The FreeBSD boxes also experience a provisioning problem,
-with the same result: the second, private network interface does not get
-configured. As these interfaces are used to run ansible from `ubuntu1`, I could
-not fully test the scripts from there.

--- a/package_updates/Vagrantfile
+++ b/package_updates/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# https://github.com/hashicorp/vagrant/issues/9442#issuecomment-363080565  
+# https://github.com/hashicorp/vagrant/issues/9442#issuecomment-363080565
 # Uncomment below if you need the work around.
 # Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
 
@@ -43,6 +43,7 @@ Vagrant.configure("2") do |config|
     freebsd5.ssh.shell = "sh"
     freebsd5.vm.base_mac = "080027D14C55"
     freebsd5.vm.synced_folder ".", "/vagrant", type: "rsync"
+    freebsd5.vm.boot_timeout = 600
   end
 
   config.vm.define "freebsd6" do |freebsd6|
@@ -53,5 +54,6 @@ Vagrant.configure("2") do |config|
     freebsd6.ssh.shell = "sh"
     freebsd6.vm.base_mac = "080027D14C66"
     freebsd6.vm.synced_folder ".", "/vagrant", type: "rsync"
+    freebsd6.vm.boot_timeout = 600
   end
 end

--- a/package_updates/base-setup.yml
+++ b/package_updates/base-setup.yml
@@ -22,24 +22,27 @@
 - name: install ubuntu1 node as ansible control machine
   hosts: ubuntu1
   tasks:
-    - apt:
+    - name: install pip
+      apt:
         name:
         - python3-pip
-    - pip:
+    - name: install/upgrade Python tools
+      pip:
         name:
           - pip
           - setuptools
-          - cryptography
-          - paramiko
         extra_args: --upgrade
-    - pip:
+    - name: install ansible
+      pip:
         name: ansible
         version: 2.5.2
     - become_user: vagrant
+      name: checkout experiments repo on controller node
       git:
         dest: ./ansible-experiments
         repo: https://github.com/stationgroup/ansible-experiments
     - become_user: vagrant
+      name: create ssh key for vagrant user
       user:
         name: vagrant
         generate_ssh_key: true

--- a/package_updates/base-setup.yml
+++ b/package_updates/base-setup.yml
@@ -32,6 +32,11 @@
           - pip
           - setuptools
         extra_args: --upgrade
+    - name: install/upgrade ansible dependency
+      pip:
+        name:
+          - cryptography
+        extra_args: --upgrade
     - name: install ansible
       pip:
         name: ansible

--- a/package_updates/os_upgrade.yml
+++ b/package_updates/os_upgrade.yml
@@ -7,7 +7,7 @@
       key: '{{ ansible_distribution }}'
 
 - name: upgrade debian based machines
-  hosts: ubuntu:FreeBSD
+  hosts: Ubuntu:FreeBSD
   gather_facts: false
   tasks:
     - include_role:

--- a/package_updates/roles/freebsd-update/tasks/main.yml
+++ b/package_updates/roles/freebsd-update/tasks/main.yml
@@ -20,6 +20,8 @@
 
 - name: Upgrade FreeBSD packages - dry-run
   command: pkg upgrade --dry-run
+  failed_when: False # --dry-run always returns failure
+                     # https://github.com/freebsd/pkg/issues/1470
   check_mode: no
   when: ansible_distribution == 'FreeBSD' and ansible_check_mode
   register: result_pkg

--- a/package_updates/setup-requirements
+++ b/package_updates/setup-requirements
@@ -1,6 +1,15 @@
 #!/bin/bash
-set -x
-set -e
+
+# c-basic-offset: 4; tab-width: 4; indent-tabs-mode: t
+# vi: set shiftwidth=4 tabstop=4 noexpandtab:
+# :indentSize=4:tabSize=4:noTabs=false:
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+
+vagrant up
 vagrant ssh-config > vagrant-ssh-config
 ansible-galaxy install -r roles/requirements.yml
 ansible-playbook --ssh-extra-args "-F ./vagrant-ssh-config" --inventory hosts-vagrant base-setup.yml


### PR DESCRIPTION
* install correct dependency version
* setup script does all from vagrant up to check upgrade'
* Fix typo - Ubuntu dynamic group name
* fix: let ansible install handle dependencies and add proper task names
* fix: pkg upgrade --dry-run always returns an error
* It is considered as the same flow as the user refusing the upgrade - See https://github.com/freebsd/pkg/issues/1470
* avoid provisioning timeout for freebsd

The only issue I *sometimes* encounter, are freebsd tasks to sometimes fail (sometimes even whilst not failing  on the other node) intermittently. Typically it fails at downloading something.